### PR TITLE
Updated test to demonstrate incorrect resolution of ${project.version} values

### DIFF
--- a/maven-external-version-plugin/src/it/multi-module/level-one/pom.xml
+++ b/maven-external-version-plugin/src/it/multi-module/level-one/pom.xml
@@ -7,15 +7,18 @@
     <artifactId>multi-module</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <groupId>com.example</groupId>
   <artifactId>level-one</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>level-one</name>
   <url>http://maven.apache.org</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>level-three</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/maven-external-version-plugin/src/it/multi-module/sub-parent/level-three/pom.xml
+++ b/maven-external-version-plugin/src/it/multi-module/sub-parent/level-three/pom.xml
@@ -7,9 +7,7 @@
     <artifactId>sub-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <groupId>com.example</groupId>
   <artifactId>level-three</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>level-three</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/maven-external-version-plugin/src/it/multi-module/sub-parent/pom.xml
+++ b/maven-external-version-plugin/src/it/multi-module/sub-parent/pom.xml
@@ -6,9 +6,7 @@
     <groupId>com.example</groupId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <groupId>com.example</groupId>
   <artifactId>sub-parent</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>sub-parent</name>
   <modules>


### PR DESCRIPTION
Added dependency between level-one module and level-three module in order to demonstrate incorrect ${project.version} resolution (see https://github.com/bdemers/maven-external-version/issues/7)

In see this issue, run `mvn install -Dexternal.version-qualifier=abc` and then `mvn dependency:tree -Dexternal.version-qualifier=abc` from within _maven-external-version-plugin/src/it/multi-module_. You'll get the error:

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.345 s
[INFO] Finished at: 2017-02-15T09:00:30+00:00
[INFO] Final Memory: 15M/303M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project level-one: Could not resolve dependencies for project com.example:level-one:jar:1.0-abc-SNAPSHOT: Failure to find com.example:level-three:jar:1.0-SNAPSHOT in https://artifactory.nativ-systems.com/artifactory/repo was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```
Maven is trying to resolve com.example:level-three:jar:1.0-SNAPSHOT, not com.example:level-three:jar:1.0-abc-SNAPSHOT